### PR TITLE
add(LivingPageExtension): default $configItems array value

### DIFF
--- a/code/extensions/LivingPageExtension.php
+++ b/code/extensions/LivingPageExtension.php
@@ -96,9 +96,10 @@ class LivingPageExtension extends DataExtension
     public function availableShortcodes() {
         $configObject = class_exists('Site') ? \Multisites::inst()->getActiveSite() : \SiteConfig::current_site_config();
 
+         $configItems = [];
         if ($configObject && $configObject->hasExtension('LivingPageSettingsExtension')) {
             $configItems = $configObject->GlobalShortcodes->getValues();
-            if (!$configItems) {
+            if (!is_array($configItems)) {
                 $configItems = [];
             }
         }

--- a/css/living-frontend.css
+++ b/css/living-frontend.css
@@ -210,7 +210,8 @@ body.doc-no-selection .livingdocs-toolbar iframe {
   margin-top: 16px;
   right: 10px;
 }
-.livingdocs-components ul li i:before, ul li i:after {
+.livingdocs-components ul li i:before, 
+.livingdocs-components ul li i:after {
   content: "";
   position: absolute;
   background-color: #ff6873;


### PR DESCRIPTION
Ensure $configItems is an array for use in array_merge, because it may not get set otherwise.